### PR TITLE
Correct python shelve and cache issue on Mac OS X

### DIFF
--- a/engineer/engine.py
+++ b/engineer/engine.py
@@ -292,7 +292,6 @@ def build(args=None):
             output = settings.COMPRESSION_CACHE[file]
         with open(file, mode='wb') as f:
             f.write(output)
-    settings.CACHE.sync()
 
     # Remove LESS files if LESS preprocessing is being done
     if settings.PREPROCESS_LESS:
@@ -326,6 +325,7 @@ def build(args=None):
 
     with open(settings.BUILD_STATS_FILE, mode='wb') as file:
         pickle.dump(build_stats, file)
+    settings.CACHE.close()
     return build_stats
 
 


### PR DESCRIPTION
The problem is that on MacOS X calling `settings.CACHE.sync()` didn't
seem to be syncing the file. I'm not certain if there were read/writes
to the cache after this that caused problems or what, but it resulted
in a broken cache file that, at least on my machine, was exactly 96KiB.

I hacked around this to call `settings.CACHE.close()` and the cache now
seems to be written properly.

This should close tylerbutler/engineer#36

Signed-off-by: Patrick Wagstrom patrick@wagstrom.net
