### PR TITLE
fix slug processing to allow for numeric tags

### DIFF
--- a/engineer/util.py
+++ b/engineer/util.py
@@ -18,7 +18,7 @@ _punctuation_regex = re.compile(r'[\t :!"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
 def slugify(text, length_limit=0, delimiter=u'-'):
     """Generates an ASCII-only slug."""
     result = []
-    for word in _punctuation_regex.split(text.lower()):
+    for word in _punctuation_regex.split(unicode(text).lower()):
         word = word.encode('translit/long')
         if word:
             result.append(word)


### PR DESCRIPTION
It appears that the YAML parsing is smart enough to see that something that is entirely numeric should be a number. For example:

```
Tags:
- 2013
- 2014
```

However, the slugify method assumed that the `text` being passed to it was actually an object with the `lower` method. In some cases, such as those above, it could be an `int` which causes `engineer build` to fail. By casting `text` to `unicode` we avoid this problem.
